### PR TITLE
Revert "Fail on fetching not enough"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,14 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/test/using_bundler/Gemfile
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2 # we are comparing PR merge head with base
+      - name: Fetch all commits for PR branch plus head commit of base branch
+        run: |
+          # fetch all commits of the PR branch
+          git fetch --shallow-exclude "${{ github.base_ref }}" origin "${{ github.ref }}"
+          # fix for "fatal: error in object: unshallow"
+          git repack -d
+          # fetch head commit of base branch
+          git fetch --deepen 1 origin "${{ github.ref }}"
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-set -o pipefail
 
 cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
@@ -96,8 +95,8 @@ if [ "${INPUT_ONLY_CHANGED}" = "true" ]; then
   # shellcheck disable=SC2086
   readarray -t CHANGED_FILES < <(
     comm -12 \
-      <(git diff --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort || kill $$) \
-      <(${BUNDLE_EXEC}rubocop --list-target-files | sort || kill $$)
+      <(git diff --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort) \
+      <(${BUNDLE_EXEC}rubocop --list-target-files | sort)
   )
 
   if (( ${#CHANGED_FILES[@]} == 0 )); then


### PR DESCRIPTION
Reverts opf/action-rubocop#9

Reverting because the changes are causing a false error on rubocop. https://github.com/opf/openproject/actions/runs/9348912991/job/25729076693