### PR TITLE
Correct pipefail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,8 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/test/using_bundler/Gemfile
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch all commits for PR branch plus head commit of base branch
-        run: |
-          # fetch all commits of the PR branch
-          git fetch --shallow-exclude "${{ github.base_ref }}" origin "${{ github.ref }}"
-          # fix for "fatal: error in object: unshallow"
-          git repack -d
-          # fetch head commit of base branch
-          git fetch --deepen 1 origin "${{ github.ref }}"
+        with:
+          fetch-depth: 2 # we are comparing PR merge head with base
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/test/using_bundler/Gemfile
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2 # we are comparing PR merge head with base
+      - name: Fetch head commit of base branch
+        run: git fetch --depth 1 origin ${{ github.event.pull_request.base.sha }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/script.sh
+++ b/script.sh
@@ -117,7 +117,12 @@ fi
 
 echo '::group:: Running rubocop with reviewdog 🐶 ...'
 # shellcheck disable=SC2086
-${BUNDLE_EXEC}rubocop ${INPUT_RUBOCOP_FLAGS} --require ${GITHUB_ACTION_PATH}/rdjson_formatter/rdjson_formatter.rb --format RdjsonFormatter "${CHANGED_FILES[@]}" \
+${BUNDLE_EXEC}rubocop \
+  ${INPUT_RUBOCOP_FLAGS} \
+  --require ${GITHUB_ACTION_PATH}/rdjson_formatter/rdjson_formatter.rb \
+  --format RdjsonFormatter \
+  --fail-level error \
+  "${CHANGED_FILES[@]}" \
   | reviewdog -f=rdjson \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \

--- a/script.sh
+++ b/script.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
@@ -95,8 +96,8 @@ if [ "${INPUT_ONLY_CHANGED}" = "true" ]; then
   # shellcheck disable=SC2086
   readarray -t CHANGED_FILES < <(
     comm -12 \
-      <(git diff --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort) \
-      <(${BUNDLE_EXEC}rubocop --list-target-files | sort)
+      <(git diff --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}" | sort || kill $$) \
+      <(${BUNDLE_EXEC}rubocop --list-target-files | sort || kill $$)
   )
 
   if (( ${#CHANGED_FILES[@]} == 0 )); then


### PR DESCRIPTION
#9 introduced a problem, as rubocop returns non-zero status when reporting violations, so changes were rolled back in #10.
Reintroducing the changes, but make rubocop fail only for severity error and fatal.